### PR TITLE
QoL fixes and proper close function call on exit

### DIFF
--- a/Tidal RPC.py
+++ b/Tidal RPC.py
@@ -23,10 +23,12 @@ import time
 import psutil
 import win32gui
 import win32process
+import os
 
 # Application ID (Enter yours here).
 client_id = "0000000000000000000"
-
+disc_found = False
+RPC = Presence(client_id)
 
 # Returns a list of windows related to the passed process ID.
 def get_windows_by_pid(pid):
@@ -61,12 +63,15 @@ def get_tidal_info():
     song_info = all_titles[0].split(" - ")
     return song_info[0], song_info[1]
 
-
-LINE_CLEAR = '\x1b[2K'
-
-RPC = Presence(client_id)
-RPC.connect()
-
+while not disc_found:
+    try:
+        RPC.connect()
+    except Exception:
+        print("Discord not running, going to sleep.")
+        time.sleep(60)
+        os.system("cls")
+    else: disc_found = True
+    
 # Update your status every 15 seconds (to stay within rate limits).
 while True:
     try:
@@ -79,7 +84,7 @@ while True:
             small_image="hra",
             small_text="Streaming lossless in up to 24-bit 192kHz."
         )
-        print(end=LINE_CLEAR)
+        os.system("cls")
         print('Rich presence active...', end='\r')
     # A catch all exception. The program should continue attempting to find the TIDAL window
     # and maintain its Discord connection under all circumstances.
@@ -89,7 +94,14 @@ while True:
             large_image="tidallogo",
             large_text="TIDAL"
         )
-        print(end=LINE_CLEAR)
+        os.system("cls")
         print("Streaming paused or window closed...", end='\r')
-    # MUST be no less than 15 seconds to remain within Discord rate limits.
-    time.sleep(15)
+    try:
+        # MUST be no less than 15 seconds to remain within Discord rate limits.
+        time.sleep(15)
+    # Terminate properly on user CTRL-C
+    except KeyboardInterrupt:
+        RPC.close()
+        os.system("cls")
+        print("Connection terminated by user. Exiting.")
+        sys.exit()

--- a/Tidal RPC.py
+++ b/Tidal RPC.py
@@ -77,8 +77,9 @@ while not disc_found:
     try:
         RPC.connect()
     except Exception:
-        print("Discord not running, going to sleep for one minute.")
+        print("Discord not running, going to sleep for one minute.", end='\n')
         try:
+            print("Hit CTRL-C if you want to terminate the script.", end='\n')
             sleep(60)
             clear()
         except KeyboardInterrupt:
@@ -99,7 +100,7 @@ while True:
             small_text="Streaming lossless in up to 24-bit 192kHz."
         )
         clear()
-        print('Rich presence active...', end='\r')
+        print("Rich presence active...", end='\n')
     # A catch all exception. The program should continue attempting to find the TIDAL window
     # and maintain its Discord connection under all circumstances.
     except Exception:
@@ -109,9 +110,10 @@ while True:
             large_text="TIDAL"
         )
         clear()
-        print("Streaming paused or window closed...", end='\r')
+        print("Streaming paused or window closed...", end='\n')
     try:
         # MUST be no less than 15 seconds to remain within Discord rate limits.
+        print("Hit CTRL-C if you want to terminate the script.", end='\n')
         sleep(15)
     # Terminate properly on user CTRL-C
     except KeyboardInterrupt:

--- a/Tidal RPC.py
+++ b/Tidal RPC.py
@@ -19,11 +19,11 @@
 
 from pypresence import Presence
 import sys
-import time
+from time import sleep
 import psutil
 import win32gui
 import win32process
-import os
+from os import system, name
 
 # Application ID (Enter yours here).
 client_id = "0000000000000000000"
@@ -62,14 +62,28 @@ def get_tidal_info():
 
     song_info = all_titles[0].split(" - ")
     return song_info[0], song_info[1]
+    
+def clear():
+ 
+    # for windows
+    if name == 'nt':
+        _ = system('cls')
+ 
+    # for mac and linux(here, os.name is 'posix')
+    else:
+        _ = system('clear')
 
 while not disc_found:
     try:
         RPC.connect()
     except Exception:
-        print("Discord not running, going to sleep.")
-        time.sleep(60)
-        os.system("cls")
+        print("Discord not running, going to sleep for one minute.")
+        try:
+            sleep(60)
+            clear()
+        except KeyboardInterrupt:
+            print("Script terminated by user. Exiting.")
+            sys.exit()
     else: disc_found = True
     
 # Update your status every 15 seconds (to stay within rate limits).
@@ -84,7 +98,7 @@ while True:
             small_image="hra",
             small_text="Streaming lossless in up to 24-bit 192kHz."
         )
-        os.system("cls")
+        clear()
         print('Rich presence active...', end='\r')
     # A catch all exception. The program should continue attempting to find the TIDAL window
     # and maintain its Discord connection under all circumstances.
@@ -94,14 +108,14 @@ while True:
             large_image="tidallogo",
             large_text="TIDAL"
         )
-        os.system("cls")
+        clear()
         print("Streaming paused or window closed...", end='\r')
     try:
         # MUST be no less than 15 seconds to remain within Discord rate limits.
-        time.sleep(15)
+        sleep(15)
     # Terminate properly on user CTRL-C
     except KeyboardInterrupt:
         RPC.close()
-        os.system("cls")
-        print("Connection terminated by user. Exiting.")
+        clear()
+        print("Script terminated by user. Exiting.")
         sys.exit()


### PR DESCRIPTION
Various tweaks to add a check/wait for Discord if it's not running.
Clear function with OS detection.
Can close properly with CTRL-C without crashing.
Proper .close() function called on exit to stop status from "sticking" in Discord.